### PR TITLE
Fix regex filter

### DIFF
--- a/Sources/telegram-vapor-bot/Telegrammer/Helpers/String+Helper.swift
+++ b/Sources/telegram-vapor-bot/Telegrammer/Helpers/String+Helper.swift
@@ -76,7 +76,7 @@ public extension Int {
 public extension String {
     func matchRegexp(pattern: String) -> Bool {
         guard let regexp = try? NSRegularExpression(pattern: pattern, options: []) else { return false }
-        let range = NSRange(location: 0, length: self.count)
+        let range = NSRange(location: 0, length: self.count + 1)
         return regexp.numberOfMatches(in: self, options: [], range: range) != 0
     }
 }

--- a/Sources/telegram-vapor-bot/Telegrammer/Helpers/String+Helper.swift
+++ b/Sources/telegram-vapor-bot/Telegrammer/Helpers/String+Helper.swift
@@ -76,7 +76,7 @@ public extension Int {
 public extension String {
     func matchRegexp(pattern: String) -> Bool {
         guard let regexp = try? NSRegularExpression(pattern: pattern, options: []) else { return false }
-        let range = NSRange(location: 0, length: self.count + 1)
+        let range = NSRange(location: 0, length: self.utf16.count)
         return regexp.numberOfMatches(in: self, options: [], range: range) != 0
     }
 }


### PR DESCRIPTION
If message has emojis, it will not match in regex filter. It happens because range is smaller than all message length.
For correct count of symbols need to use UTF16 view of string.