### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(name: "SwiftRegularExpression", url: "https://github.com/nerzh/swift-regular-expression", .upToNextMajor(from: "0.2.4")),
     ],
     targets: [
-        .target(
+        .executableTarget(
             name: "TelegramVaporBot",
             dependencies: [
                 .product(name: "Vapor", package: "vapor"),


### PR DESCRIPTION
an issue: 'TelegramVaporBot' was identified as an executable target given the presence of a 'main.swift' file. Starting with tools version 5.4.0 executable targets should be declared as 'executableTarget()'