### PR TITLE
add common properties to TGMaybeInaccessibleMessage 

### DIFF
--- a/Sources/TelegramVaporBot/Bot/Telegram/ModelExtensions/TGMaybeInaccessibleMessageExtensions.swift
+++ b/Sources/TelegramVaporBot/Bot/Telegram/ModelExtensions/TGMaybeInaccessibleMessageExtensions.swift
@@ -1,11 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Hadi Sharghi on 2024-01-10.
-//
-
-import Foundation
+// Telegram-vapor-bot - Telegram Bot Swift SDK.
 
 /**
  This extension adds common properties betwwen TGMessage and TGInaccessibleMessage (chat, messageId and date) to TGMaybeInaccessibleMessage. These properties are always accessible no mather TGInaccessibleMessage is TGMessage or TGInaccessibleMessage.

--- a/Sources/TelegramVaporBot/Bot/Telegram/ModelExtensions/TGMaybeInaccessibleMessageExtensions.swift
+++ b/Sources/TelegramVaporBot/Bot/Telegram/ModelExtensions/TGMaybeInaccessibleMessageExtensions.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  
+//
+//  Created by Hadi Sharghi on 2024-01-10.
+//
+
+import Foundation
+
+/**
+ This extension adds common properties betwwen TGMessage and TGInaccessibleMessage (chat, messageId and date) to TGMaybeInaccessibleMessage. These properties are always accessible no mather TGInaccessibleMessage is TGMessage or TGInaccessibleMessage.
+ 
+ SeeAlso Telegram Bot API Reference:
+ [MaybeInaccessibleMessage](https://core.telegram.org/bots/api#maybeinaccessiblemessage)
+ **/
+
+public extension TGMaybeInaccessibleMessage {
+    var chat: TGChat {
+        switch self {
+        case .inaccessibleMessage(let msg):
+            return msg.chat
+        case .message(let msg):
+            return msg.chat
+        }
+    }
+    
+    var messageId: Int {
+        switch self {
+        case .inaccessibleMessage(let msg):
+            return msg.messageId
+        case .message(let msg):
+            return msg.messageId
+        }
+    }
+    
+    var date: Int {
+        switch self {
+        case .inaccessibleMessage(let msg):
+            return msg.date
+        case .message(let msg):
+            return msg.date
+        }
+    }
+}

--- a/Sources/TelegramVaporBot/Bot/Telegram/Models/TGMaybeInaccessibleMessage.swift
+++ b/Sources/TelegramVaporBot/Bot/Telegram/Models/TGMaybeInaccessibleMessage.swift
@@ -12,3 +12,33 @@ public enum TGMaybeInaccessibleMessage: Codable {
     case message(TGMessage)
     case inaccessibleMessage(TGInaccessibleMessage)
 }
+
+
+public extension TGMaybeInaccessibleMessage {
+    var chat: TGChat {
+        switch self {
+        case .inaccessibleMessage(let msg):
+            return msg.chat
+        case .message(let msg):
+            return msg.chat
+        }
+    }
+    
+    var messageId: Int {
+        switch self {
+        case .inaccessibleMessage(let msg):
+            return msg.messageId
+        case .message(let msg):
+            return msg.messageId
+        }
+    }
+    
+    var date: Int {
+        switch self {
+        case .inaccessibleMessage(let msg):
+            return msg.date
+        case .message(let msg):
+            return msg.date
+        }
+    }
+}

--- a/Sources/TelegramVaporBot/Bot/Telegram/Models/TGMaybeInaccessibleMessage.swift
+++ b/Sources/TelegramVaporBot/Bot/Telegram/Models/TGMaybeInaccessibleMessage.swift
@@ -13,32 +13,3 @@ public enum TGMaybeInaccessibleMessage: Codable {
     case inaccessibleMessage(TGInaccessibleMessage)
 }
 
-
-public extension TGMaybeInaccessibleMessage {
-    var chat: TGChat {
-        switch self {
-        case .inaccessibleMessage(let msg):
-            return msg.chat
-        case .message(let msg):
-            return msg.chat
-        }
-    }
-    
-    var messageId: Int {
-        switch self {
-        case .inaccessibleMessage(let msg):
-            return msg.messageId
-        case .message(let msg):
-            return msg.messageId
-        }
-    }
-    
-    var date: Int {
-        switch self {
-        case .inaccessibleMessage(let msg):
-            return msg.date
-        case .message(let msg):
-            return msg.date
-        }
-    }
-}


### PR DESCRIPTION
According to API docs v7, both `Message` and `InaccessibleMessage` share 3 common properties 
- chat
- messageId
- date

To make those properties available when accessing `TGMaybeInaccessibleMessage` a public extension has been added to `TGMaybeInaccessibleMessage`. 
Now any `TGMaybeInaccessibleMessage` instance can have access to the above properties.

It causes no breaking to new API and also prevents older codes to break.