### PR TITLE
Fix deprecation in Telegram-bot-example

### DIFF
--- a/Telegram-bot-example/Sources/Telegram-bot-example/main.swift
+++ b/Telegram-bot-example/Sources/Telegram-bot-example/main.swift
@@ -9,4 +9,4 @@ let TGBOT: TGBotConnection = .init()
 
 defer { app.shutdown() }
 try await configure(app)
-try app.run()
+try await app.execute()


### PR DESCRIPTION
```
/***/telegram-vapor-bot/Telegram-bot-example/Sources/Telegram-bot-example/main.swift:12:9: warning: instance method 'run' is unavailable from asynchronous contexts; Use the async execute() method instead.; this is an error in Swift 6
try app.run()
```