### PR TITLE
Fix warning in Telegram-bot-example/main.swift

### DIFF
--- a/Telegram-bot-example/Sources/Telegram-bot-example/main.swift
+++ b/Telegram-bot-example/Sources/Telegram-bot-example/main.swift
@@ -4,7 +4,7 @@ import TelegramVaporBot
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)
 let eventLoop: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount * 4)
-let app: Application = try! await Application.make(env, Application.EventLoopGroupProvider.shared(eventLoop))
+let app: Application = try await Application.make(env, Application.EventLoopGroupProvider.shared(eventLoop))
 let TGBOT: TGBotConnection = .init()
 
 defer { app.shutdown() }

--- a/Telegram-bot-example/Sources/Telegram-bot-example/main.swift
+++ b/Telegram-bot-example/Sources/Telegram-bot-example/main.swift
@@ -4,7 +4,7 @@ import TelegramVaporBot
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)
 let eventLoop: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount * 4)
-let app: Application = .init(env, Application.EventLoopGroupProvider.shared(eventLoop))
+let app: Application = try! await Application.make(env, Application.EventLoopGroupProvider.shared(eventLoop))
 let TGBOT: TGBotConnection = .init()
 
 defer { app.shutdown() }


### PR DESCRIPTION
Fix warning `Initializer 'init' is unavailable from asynchronous contexts; This initialiser cannot be used in async contexts, Application.makeApplication() instead; this is an error in Swift 6`.